### PR TITLE
fix(comment): ignore markdown comments

### DIFF
--- a/gen3git.py
+++ b/gen3git.py
@@ -176,7 +176,7 @@ def get_command_line_args():
         "--to-date",
         type=str,
         help="Date to stop collecting release notes at (inclusive), format - YYYY-MM-DD, "
-             "Overrides --to-tag argument. If not specified, falls back to default --to-tag.",
+        "Overrides --to-tag argument. If not specified, falls back to default --to-tag.",
     )
     gen.add_argument(
         "--file-name",
@@ -322,9 +322,9 @@ def main(args=None):
     stop_date = stop_commit.commit.author.date + timedelta(0, 5)
 
     # If dates are specified by the user, they override dates from tags/commits
-    if hasattr(args, 'from_date') and args.from_date is not None:
+    if hasattr(args, "from_date") and args.from_date is not None:
         start_date = datetime.strptime(args.from_date, "%Y-%m-%d")
-    if hasattr(args, 'to_date') and args.to_date is not None:
+    if hasattr(args, "to_date") and args.to_date is not None:
         stop_date = datetime.strptime(args.to_date, "%Y-%m-%d")
 
     for commit in repo.get_commits(since=start_date, until=stop_date):
@@ -455,6 +455,7 @@ def parse_line(line):
         or line == "Implemented XXX"
         or line == "This pull request was generated automatically."
         or line == "None"
+        or (line.startswith("<!--") and line.endswith("-->"))
     ):
         return None
 


### PR DESCRIPTION

### Improvements
- Add markdown comments to the list of lines to ignore in release notes
