### PR TITLE
fix(gen3git): Fix logging for _GITHUB_REMOTE regex check

### DIFF
--- a/gen3git.py
+++ b/gen3git.py
@@ -255,7 +255,7 @@ def main(args=None):
 
         matches = _GITHUB_REMOTE.findall(uri)
         if not matches:
-            print(f"Unable to match remote uri {uri} to regex \`{_GITHUB_REMOTE}\`")
+            print(f"Unable to match remote uri {uri} to regex {_GITHUB_REMOTE}")
             return
         uri = "".join(matches[0])
 

--- a/gen3git.py
+++ b/gen3git.py
@@ -255,7 +255,7 @@ def main(args=None):
 
         matches = _GITHUB_REMOTE.findall(uri)
         if not matches:
-            print(f"Unable to match remote uri {uri} to regex `{_GITHUB_REMOTE}`")
+            print(f"Unable to match remote uri {uri} to regex \`{_GITHUB_REMOTE}\`")
             return
         uri = "".join(matches[0])
 


### PR DESCRIPTION
Here's the issue:
```
  File "/home/runner/work/pypfb/pypfb/src/gen3git/gen3git.py", line 258
    print(f"Unable to match remote uri {uri} to regex `{_GITHUB_REMOTE}`")
                                                                        ^
SyntaxError: invalid syntax
```

Testing this here: https://github.com/uc-cdis/pypfb/pull/65

### Improvements
- Fix logging for _GITHUB_REMOTE regex check