### PR TITLE
Add auth headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,4 @@ More options are available for the `gen3git` CLI.
 gen3git --help
 ```
 
-You only need access token for private repos or workaround GitHub rate limit. This
-script should be able to read from public repos without the need to set the
-`GITHUB_ACCESS_TOKEN`.
+You only need access token for private repos or workaround GitHub rate limit. The token should be provided by setting `GH_TOKEN` or `GITHUB_TOKEN`. This script should be able to read from public repos without it.

--- a/gen3git.py
+++ b/gen3git.py
@@ -206,7 +206,7 @@ def get_command_line_args():
     parser.add_argument(
         "--github-access-token",
         type=str,
-        default=os.environ.get("GH_TOKEN"),
+        default=os.environ.get("GH_TOKEN", os.environ.get("GITHUB_TOKEN")),
         help="GitHub access token for accessing private repositories if any.",
     )
 

--- a/gen3git.py
+++ b/gen3git.py
@@ -234,6 +234,12 @@ def main(args=None):
     else:
         g = Github()
 
+    headers = {}
+    if args.github_access_token:
+        headers = {"Authorization", f"token {args.github_access_token}"}
+    else:
+        print("No GitHub access token provided. Will fail to access private repos.")
+
     # Get GitHub Repository
     git = Repo(search_parent_directories=True)
     if args.repo:
@@ -336,7 +342,8 @@ def main(args=None):
         # https://github.blog/2014-10-13-linking-merged-pull-requests-from-commits/
         # We are not using the search API because its rate limit is too low
         resp = requests.get(
-            "https://github.com/%s/branch_commits/%s" % (uri, commit.sha)
+            "https://github.com/%s/branch_commits/%s" % (uri, commit.sha),
+            headers=headers,
         )
         resp.raise_for_status()
         prs = _GITHUB_PR.findall(resp.text)


### PR DESCRIPTION
closes #17

### Improvements
- Use GitHub token when making custom calls to the GitHub API so we can access private repos
- Accept both "GH_TOKEN" and "GITHUB_TOKEN"