### PR TITLE
chore(ci): Skip PR description checks for private repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,4 @@ More options are available for the `gen3git` CLI.
 gen3git --help
 ```
 
-You only need access token for private repos or workaround GitHub rate limit. This
-script should be able to read from public repos without the need to set the
-`GITHUB_ACCESS_TOKEN`.
+You only need access token for private repos or workaround GitHub rate limit. The token should be provided by setting `GH_TOKEN` or `GITHUB_TOKEN`. This script should be able to read from public repos without it.

--- a/README.md
+++ b/README.md
@@ -61,4 +61,6 @@ More options are available for the `gen3git` CLI.
 gen3git --help
 ```
 
-You only need access token for private repos or workaround GitHub rate limit. The token should be provided by setting `GH_TOKEN` or `GITHUB_TOKEN`. This script should be able to read from public repos without it.
+You only need access token for private repos or workaround GitHub rate limit. This
+script should be able to read from public repos without the need to set the
+`GITHUB_ACCESS_TOKEN`.

--- a/gen3git.py
+++ b/gen3git.py
@@ -333,7 +333,7 @@ def main(args=None):
         stop_date = datetime.strptime(args.to_date, "%Y-%m-%d")
 
     # TODO: Revisit this whole logic to adopt proper githubapi requests
-    # instead of this `branch_commits` approach that is not compatible with private repos
+    # instead of this `branch_commits` approach that is not compatible with private repos. See ticket PXP-7714
     # Skipping private repos for now
     private_check = requests.get(
         "https://api.github.com/repos/%s" % (uri),
@@ -342,12 +342,15 @@ def main(args=None):
     resp.raise_for_status()
     private_check_json = private_check.json()
     if private_check_json["private"] == True:
+        print("Cannot access private repos at the moment - exiting")
         sys.exit(0)
 
     for commit in repo.get_commits(since=start_date, until=stop_date):
         # https://platform.github.community/t/get-pull-request-associated-with-merge-commit/6936
         # https://github.blog/2014-10-13-linking-merged-pull-requests-from-commits/
-        # We are not using the search API because its rate limit is too low
+        # We are not using the search API because its rate limit is too low.
+        # This doesn't work for private repos, and we can't attach headers
+        # because it's not a GitHub API endpoint. See ticket PXP-7714
         resp = requests.get(
             "https://github.com/%s/branch_commits/%s" % (uri, commit.sha)
         )

--- a/gen3git.py
+++ b/gen3git.py
@@ -237,7 +237,7 @@ def main(args=None):
 
     headers = {}
     if args.github_access_token:
-        headers = {"Authorization": f"token {args.github_access_token}"}
+        headers = {"Authorization", f"token {args.github_access_token}"}
     else:
         print("No GitHub access token provided. Will fail to access private repos.")
 

--- a/gen3git.py
+++ b/gen3git.py
@@ -207,7 +207,7 @@ def get_command_line_args():
     parser.add_argument(
         "--github-access-token",
         type=str,
-        default=os.environ.get("GH_TOKEN"),
+        default=os.environ.get("GH_TOKEN", os.environ.get("GITHUB_TOKEN")),
         help="GitHub access token for accessing private repositories if any.",
     )
 

--- a/gen3git.py
+++ b/gen3git.py
@@ -207,7 +207,7 @@ def get_command_line_args():
     parser.add_argument(
         "--github-access-token",
         type=str,
-        default=os.environ.get("GH_TOKEN", os.environ.get("GITHUB_TOKEN")),
+        default=os.environ.get("GH_TOKEN"),
         help="GitHub access token for accessing private repositories if any.",
     )
 
@@ -234,12 +234,6 @@ def main(args=None):
         g = Github(args.github_access_token)
     else:
         g = Github()
-
-    headers = {}
-    if args.github_access_token:
-        headers = {"Authorization", f"token {args.github_access_token}"}
-    else:
-        print("No GitHub access token provided. Will fail to access private repos.")
 
     # Get GitHub Repository
     git = Repo(search_parent_directories=True)
@@ -355,8 +349,7 @@ def main(args=None):
         # https://github.blog/2014-10-13-linking-merged-pull-requests-from-commits/
         # We are not using the search API because its rate limit is too low
         resp = requests.get(
-            "https://github.com/%s/branch_commits/%s" % (uri, commit.sha),
-            headers=headers,
+            "https://github.com/%s/branch_commits/%s" % (uri, commit.sha)
         )
         resp.raise_for_status()
         prs = _GITHUB_PR.findall(resp.text)

--- a/gen3git.py
+++ b/gen3git.py
@@ -6,6 +6,7 @@ to create release notes.
 import argparse
 import os
 import re
+import sys
 
 import requests
 from datetime import datetime, timedelta
@@ -336,6 +337,18 @@ def main(args=None):
         start_date = datetime.strptime(args.from_date, "%Y-%m-%d")
     if hasattr(args, "to_date") and args.to_date is not None:
         stop_date = datetime.strptime(args.to_date, "%Y-%m-%d")
+
+    # TODO: Revisit this whole logic to adopt proper githubapi requests
+    # instead of this `branch_commits` approach that is not compatible with private repos
+    # Skipping private repos for now
+    private_check = requests.get(
+        "https://api.github.com/repos/%s" % (uri),
+        headers=headers,
+    )
+    resp.raise_for_status()
+    private_check_json = private_check.json()
+    if private_check_json["private"] == True:
+        sys.exit(0)
 
     for commit in repo.get_commits(since=start_date, until=stop_date):
         # https://platform.github.community/t/get-pull-request-associated-with-merge-commit/6936


### PR DESCRIPTION
Unfortunately, the `"https://github.com/%s/branch_commits/%s" % (uri, commit.sha)` request does not work for PRIVATE repos.

This is blocking a PR that is required for some critical testing: https://github.com/uc-cdis/gitops-qa/pull/1213