### PR TITLE
skip upper version tag

### DIFF
--- a/gen3git.py
+++ b/gen3git.py
@@ -305,6 +305,8 @@ def main(args=None):
         start_tag = None
         for tag in repo.get_tags():
             ver = parse_version(tag.name)
+            if upper_bound and ver == upper_bound:
+                continue
             if (
                 not start_tag
                 or ver > parse_version(start_tag.name)

--- a/gen3git.py
+++ b/gen3git.py
@@ -305,6 +305,7 @@ def main(args=None):
         start_tag = None
         for tag in repo.get_tags():
             ver = parse_version(tag.name)
+            # account for case where no start tag and ver is same as upper_bound
             if upper_bound and ver == upper_bound:
                 continue
             if (


### PR DESCRIPTION
https://ctds-planx.atlassian.net/browse/PXP-7082

If user does not manually specify a from-tag, programs to find the most recent tag below the release tag but may occasionally fail to do so, instead releasing updates from tag n to n. This was because the program looks for the largest tag version but failed to exclude the release tag when start tag is not yet set. 


### Bug Fixes
Fixes bug where release notes output no changes


