### PR TITLE
Fix duplicate Dependency Updates sections

### DIFF
--- a/gen3git.py
+++ b/gen3git.py
@@ -450,7 +450,7 @@ def parse_pr_body(body, release_notes, ref):
 
         # handle dependabot PRs
         if "Dependabot commands and options" in body:
-            category = "Dependency Updates"
+            category = "dependency updates"
             for line in body.splitlines():
                 if line.startswith("Bumps"):
                     release_notes.setdefault(category, []).append(


### PR DESCRIPTION
dependabot updates were in category "Dependency Updates", and other updates in category "dependency updates" so we ended up with duplicate sections

### Bug Fixes
- Fix duplicate Dependency Updates sections
