### PR TITLE
If no stop is provided, use now()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 dist: xenial
 python:
 - 2.7
-- 3.7
+- 3.9
 install:
 - pip install pipenv
 - pipenv install --dev
@@ -18,7 +18,7 @@ deploy:
   skip_existing: true
   skip_cleanup: true
   on:
-    python: 3.7
+    python: 3.9
     repo: uc-cdis/release-helper
     tags: true
   password:

--- a/gen3git.py
+++ b/gen3git.py
@@ -333,9 +333,7 @@ def main(args=None):
     # add 1 second to the start date because the start commit should
     # be excluded from the result:
     start_date = start_tag.commit.commit.author.date + timedelta(0, 1)
-    # add 5 seconds to the stop date because the PR's "merged_at" date may
-    # be a few seconds after the merged commit is created in master:
-    stop_date = stop_commit.commit.author.date + timedelta(0, 5)
+    stop_date = datetime.now()
 
     # If dates are specified by the user, they override dates from tags/commits
     if hasattr(args, "from_date") and args.from_date is not None:


### PR DESCRIPTION
If no `stop_tag` is provided, use the current time as `stop_date` instead of using the date of the latest commit. The date of the latest commit may be earlier than the date the PR was merged, which causes the condition `if repo_pr.merged_at <= stop_date` to ignore this PR

### Bug Fixes
- If no `stop_tag` is provided, use the current time as the date to stop parsing release notes

### Dependency updates
- Python 3.9