### PR TITLE
Ignore GitHub autolinks

### DIFF
--- a/gen3git.py
+++ b/gen3git.py
@@ -543,6 +543,7 @@ def parse_line(line):
         or line == "This pull request was generated automatically."
         or line == "None"
         or (line.startswith("<!--") and line.endswith("-->"))
+        or re.compile(r"^\[.*\]: http.*$").match(line)  # ignore github autolinks
     ):
         return None
 


### PR DESCRIPTION
Github has started automatically adding references at the bottom of PR descriptions whenever we add a link. These should not get picked up by the release notes parser.

### New Features
- Ignore GitHub autolinks

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
