### PR TITLE
make merged_at offset-aware

### DIFF
--- a/gen3git.py
+++ b/gen3git.py
@@ -445,7 +445,7 @@ def main(args=None):
                     # only parse the PR description if it was merged after the
                     # stop date. (ignore commits that were pushed before the
                     # stop date if their PR was merged after)
-                    if repo_pr.merged_at <= stop_date:
+                    if repo_pr.merged_at.replace(tzinfo=pytz.UTC) <= stop_date:
                         desc_bodies.append((pr, "pr", repo_pr.body))
         else:
             print("Commit %s: no PR" % commit.sha)


### PR DESCRIPTION
make `repo_pr.merged_at` offset_aware (tz_aware). This is done to avoid seeing  the error `TypeError: can't compare offset-naive and offset-aware datetimes` as stop_date is offset_aware and merged_at is offset_naive. Both cant be compared to each other as both dates should be either offset naive or offset_aware

### Bug Fixes
  - Fix another timezone awareness error when comparing datetimes